### PR TITLE
Save all arguments before calling the original function

### DIFF
--- a/DynamicHooks/convention.h
+++ b/DynamicHooks/convention.h
@@ -254,7 +254,8 @@ public:
 		size_t offset = 0;
 		for (size_t i = 0; i < m_vecArgTypes.length(); i++) {
 			DataTypeSized_t &type = m_vecArgTypes[i];
-			memcpy(pSavedCallArguments + offset, GetArgumentPtr(i, pRegisters), type.size);
+			memcpy((void *)((unsigned long)pSavedCallArguments + offset), GetArgumentPtr(i, pRegisters), type.size);
+			offset += type.size;
 		}
 		m_pSavedCallArguments.append(pSavedCallArguments);
 	}
@@ -265,7 +266,8 @@ public:
 		size_t offset = 0;
 		for (size_t i = 0; i < m_vecArgTypes.length(); i++) {
 			DataTypeSized_t &type = m_vecArgTypes[i];
-			memcpy(GetArgumentPtr(i, pRegisters), pSavedCallArguments + offset, type.size);
+			memcpy(GetArgumentPtr(i, pRegisters), (void *)((unsigned long)pSavedCallArguments + offset), type.size);
+			offset += type.size;
 		}
 		m_pSavedCallArguments.pop();
 	}

--- a/DynamicHooks/convention.h
+++ b/DynamicHooks/convention.h
@@ -186,7 +186,7 @@ public:
 	virtual void** GetStackArgumentPtr(CRegisters* pRegisters) = 0;
 
 	/*
-	Returns the number of bytes that the buffer to store all the arguments in that are passed in a register.
+	Returns the number of bytes for the buffer to store all the arguments that are passed in a register in.
 	*/
 	virtual int GetArgRegisterSize() = 0;
 
@@ -219,6 +219,9 @@ public:
 
 	/*
 	Save the return value in a seperate buffer, so we can restore it after calling the original function.
+
+	@param <pRegisters>:
+	A snapshot of all saved registers.
 	*/
 	virtual void SaveReturnValue(CRegisters* pRegisters)
 	{
@@ -235,8 +238,37 @@ public:
 		m_pSavedReturnBuffers.pop();
 	}
 
-	virtual void SavePostCallRegisters(CRegisters* pRegisters) {}
-	virtual void RestorePostCallRegisters(CRegisters* pRegisters)	{}
+	/*
+	Save the value of arguments in a seperate buffer for the post callback.
+	Compiler optimizations might cause the registers or stack space to be reused
+	and overwritten during function execution if the value isn't needed anymore
+	at some point. This leads to different values in the post hook.
+
+	@param <pRegisters>:
+	A snapshot of all saved registers.
+	*/
+	virtual void SaveCallArguments(CRegisters* pRegisters)
+	{
+		int size = GetArgStackSize() + GetArgRegisterSize();
+		uint8_t* pSavedCallArguments = new uint8_t[size];
+		size_t offset = 0;
+		for (size_t i = 0; i < m_vecArgTypes.length(); i++) {
+			DataTypeSized_t &type = m_vecArgTypes[i];
+			memcpy(pSavedCallArguments + offset, GetArgumentPtr(i, pRegisters), type.size);
+		}
+		m_pSavedCallArguments.append(pSavedCallArguments);
+	}
+
+	virtual void RestoreCallArguments(CRegisters* pRegisters)
+	{
+		uint8_t* pSavedCallArguments = m_pSavedCallArguments.back();
+		size_t offset = 0;
+		for (size_t i = 0; i < m_vecArgTypes.length(); i++) {
+			DataTypeSized_t &type = m_vecArgTypes[i];
+			memcpy(GetArgumentPtr(i, pRegisters), pSavedCallArguments + offset, type.size);
+		}
+		m_pSavedCallArguments.pop();
+	}
 
 public:
 	ke::Vector<DataTypeSized_t> m_vecArgTypes;
@@ -244,6 +276,8 @@ public:
 	int m_iAlignment;
 	// Save the return in case we call the original function and want to override the return again.
 	ke::Vector<ke::AutoPtr<uint8_t>> m_pSavedReturnBuffers;
+	// Save call arguments in case the function reuses the space and overwrites the values for the post hook.
+	ke::Vector<ke::AutoPtr<uint8_t>> m_pSavedCallArguments;
 };
 
 #endif // _CONVENTION_H

--- a/DynamicHooks/conventions/x86GccThiscall.cpp
+++ b/DynamicHooks/conventions/x86GccThiscall.cpp
@@ -69,16 +69,15 @@ void** x86GccThiscall::GetStackArgumentPtr(CRegisters* pRegisters)
 	return (void **)(pRegisters->m_esp->GetValue<unsigned long>() + 4 + GetDataTypeSize(type, m_iAlignment));
 }
 
-void x86GccThiscall::SavePostCallRegisters(CRegisters* pRegisters)
+void x86GccThiscall::SaveCallArguments(CRegisters* pRegisters)
 {
-	uint8_t* pSavedThisPointer = new uint8_t[sizeof(size_t)];
-	memcpy(pSavedThisPointer, GetArgumentPtr(0, pRegisters), sizeof(size_t));
-	m_pSavedThisPointers.append(pSavedThisPointer);
-}
-
-void x86GccThiscall::RestorePostCallRegisters(CRegisters* pRegisters)
-{
-	uint8_t* pSavedThisPointer = m_pSavedThisPointers.back();
-	memcpy(GetArgumentPtr(0, pRegisters), pSavedThisPointer, sizeof(size_t));
-	m_pSavedThisPointers.pop();
+	// Count the this pointer.
+	int size = x86GccCdecl::GetArgStackSize() + GetArgRegisterSize();
+	uint8_t* pSavedCallArguments = new uint8_t[size];
+	size_t offset = 0;
+	for (size_t i = 0; i < m_vecArgTypes.length(); i++) {
+		DataTypeSized_t &type = m_vecArgTypes[i];
+		memcpy(pSavedCallArguments + offset, GetArgumentPtr(i, pRegisters), type.size);
+	}
+	m_pSavedCallArguments.append(pSavedCallArguments);
 }

--- a/DynamicHooks/conventions/x86GccThiscall.cpp
+++ b/DynamicHooks/conventions/x86GccThiscall.cpp
@@ -77,7 +77,8 @@ void x86GccThiscall::SaveCallArguments(CRegisters* pRegisters)
 	size_t offset = 0;
 	for (size_t i = 0; i < m_vecArgTypes.length(); i++) {
 		DataTypeSized_t &type = m_vecArgTypes[i];
-		memcpy(pSavedCallArguments + offset, GetArgumentPtr(i, pRegisters), type.size);
+		memcpy((void *)((unsigned long)pSavedCallArguments + offset), GetArgumentPtr(i, pRegisters), type.size);
+		offset += type.size;
 	}
 	m_pSavedCallArguments.append(pSavedCallArguments);
 }

--- a/DynamicHooks/conventions/x86GccThiscall.h
+++ b/DynamicHooks/conventions/x86GccThiscall.h
@@ -52,11 +52,7 @@ public:
 	virtual int GetArgStackSize();
 	virtual void** GetStackArgumentPtr(CRegisters* pRegisters);
 
-	virtual void SavePostCallRegisters(CRegisters* pRegisters);
-	virtual void RestorePostCallRegisters(CRegisters* pRegisters);
-
-private:
-	ke::Vector<ke::AutoPtr<uint8_t>> m_pSavedThisPointers;
+	virtual void SaveCallArguments(CRegisters* pRegisters);
 };
 
 #endif // _X86_GCC_THISCALL_H

--- a/DynamicHooks/conventions/x86MsThiscall.cpp
+++ b/DynamicHooks/conventions/x86MsThiscall.cpp
@@ -215,7 +215,8 @@ void x86MsThiscall::SaveCallArguments(CRegisters* pRegisters)
 	size_t offset = sizeof(void *);
 	for (size_t i = 0; i < m_vecArgTypes.length(); i++) {
 		DataTypeSized_t &type = m_vecArgTypes[i];
-		memcpy(pSavedCallArguments + offset, GetArgumentPtr(i + 1, pRegisters), type.size);
+		memcpy((void *)((unsigned long)pSavedCallArguments + offset), GetArgumentPtr(i + 1, pRegisters), type.size);
+		offset += type.size;
 	}
 	m_pSavedCallArguments.append(pSavedCallArguments);
 }
@@ -228,7 +229,8 @@ void x86MsThiscall::RestoreCallArguments(CRegisters* pRegisters)
 	size_t offset = sizeof(void *);
 	for (size_t i = 0; i < m_vecArgTypes.length(); i++) {
 		DataTypeSized_t &type = m_vecArgTypes[i];
-		memcpy(GetArgumentPtr(i + 1, pRegisters), pSavedCallArguments + offset, type.size);
+		memcpy(GetArgumentPtr(i + 1, pRegisters), (void *)((unsigned long)pSavedCallArguments + offset), type.size);
+		offset += type.size;
 	}
 	m_pSavedCallArguments.pop();
 }

--- a/DynamicHooks/conventions/x86MsThiscall.h
+++ b/DynamicHooks/conventions/x86MsThiscall.h
@@ -81,12 +81,11 @@ public:
 	virtual void* GetReturnPtr(CRegisters* pRegisters);
 	virtual void ReturnPtrChanged(CRegisters* pRegisters, void* pReturnPtr);
 
-	virtual void SavePostCallRegisters(CRegisters* pRegisters);
-	virtual void RestorePostCallRegisters(CRegisters* pRegisters);
+	virtual void SaveCallArguments(CRegisters* pRegisters);
+	virtual void RestoreCallArguments(CRegisters* pRegisters);
 
 private:
 	void* m_pReturnBuffer;
-	ke::Vector<ke::AutoPtr<uint8_t>> m_pSavedThisPointers;
 };
 
 #endif // _X86_MS_THISCALL_H

--- a/DynamicHooks/hook.cpp
+++ b/DynamicHooks/hook.cpp
@@ -154,7 +154,7 @@ bool CHook::AreCallbacksRegistered()
 
 ReturnAction_t CHook::HookHandler(HookType_t eHookType)
 {
-	if (eHookType == HOOKTYPE_POST && !m_LastPreReturnAction.empty())
+	if (eHookType == HOOKTYPE_POST)
 	{
 		// Ignore hooks without a registered pre-hook handler.
 		ReturnAction_t lastPreReturnAction = m_LastPreReturnAction.back();
@@ -162,13 +162,22 @@ ReturnAction_t CHook::HookHandler(HookType_t eHookType)
 		if (lastPreReturnAction == ReturnAction_Override)
 			m_pCallingConvention->RestoreReturnValue(m_pRegisters);
 		if (lastPreReturnAction < ReturnAction_Supercede)
-			m_pCallingConvention->RestorePostCallRegisters(m_pRegisters);
+			m_pCallingConvention->RestoreCallArguments(m_pRegisters);
 	}
 
 	ReturnAction_t returnAction = ReturnAction_Ignored;
 	HookTypeMap::Result r = m_hookHandler.find(eHookType);
 	if (!r.found())
+	{
+		// Still save the arguments for the post hook even if there
+		// is no pre-handler registered.
+		if (eHookType == HOOKTYPE_PRE)
+		{
+			m_LastPreReturnAction.append(returnAction);
+			m_pCallingConvention->SaveCallArguments(m_pRegisters);
+		}
 		return returnAction;
+	}
 
 	HookHandlerSet &callbacks = r->value;
 	for(HookHandlerSet::iterator it=callbacks.iter(); !it.empty(); it.next())
@@ -184,7 +193,7 @@ ReturnAction_t CHook::HookHandler(HookType_t eHookType)
 		if (returnAction == ReturnAction_Override)
 			m_pCallingConvention->SaveReturnValue(m_pRegisters);
 		if (returnAction < ReturnAction_Supercede)
-			m_pCallingConvention->SavePostCallRegisters(m_pRegisters);
+			m_pCallingConvention->SaveCallArguments(m_pRegisters);
 	}
 
 	return returnAction;

--- a/DynamicHooks/hook.cpp
+++ b/DynamicHooks/hook.cpp
@@ -156,7 +156,6 @@ ReturnAction_t CHook::HookHandler(HookType_t eHookType)
 {
 	if (eHookType == HOOKTYPE_POST)
 	{
-		// Ignore hooks without a registered pre-hook handler.
 		ReturnAction_t lastPreReturnAction = m_LastPreReturnAction.back();
 		m_LastPreReturnAction.pop();
 		if (lastPreReturnAction == ReturnAction_Override)


### PR DESCRIPTION
Save the value of arguments in a seperate buffer for the post callback.
Compiler optimizations might cause the registers or stack space to be reused and overwritten during function execution if the value isn't needed anymore at some point. This lead to different values in the post hook.

Now the post callback is guaranteed to have access to the same arguments the function was called with.

#2 