### PR TITLE
Fix memory leaks

### DIFF
--- a/vhook.cpp
+++ b/vhook.cpp
@@ -440,6 +440,7 @@ void *Callback(DHooksCallback *dg, void **argStack)
 			g_SHPtr->SetRes(MRES_SUPERCEDE);
 			mres = MRES_SUPERCEDE;
 			ret = CallVFunction<void *>(dg, paramStruct, g_SHPtr->GetIfacePtr());
+			g_SHPtr->EndContext(NULL);
 			break;
 		case MRES_ChangedOverride:
 			if(dg->returnType != ReturnType_Void)
@@ -467,6 +468,7 @@ void *Callback(DHooksCallback *dg, void **argStack)
 			g_SHPtr->SetRes(MRES_SUPERCEDE);
 			mres = MRES_SUPERCEDE;
 			CallVFunction<void *>(dg, paramStruct, g_SHPtr->GetIfacePtr());
+			g_SHPtr->EndContext(NULL);
 			break;
 		case MRES_Override:
 			if(dg->returnType != ReturnType_Void)
@@ -520,6 +522,7 @@ void *Callback(DHooksCallback *dg, void **argStack)
 				g_SHPtr->DoRecall();
 				g_SHPtr->SetRes(MRES_SUPERCEDE);
 				mres = MRES_SUPERCEDE;
+				g_SHPtr->EndContext(NULL);
 			}
 			break;
 		default:
@@ -621,6 +624,7 @@ float Callback_float(DHooksCallback *dg, void **argStack)
 			g_SHPtr->SetRes(MRES_SUPERCEDE);
 			mres = MRES_SUPERCEDE;
 			*(float *)ret = CallVFunction<float>(dg, paramStruct, g_SHPtr->GetIfacePtr());
+			g_SHPtr->EndContext(NULL);
 			break;
 		case MRES_ChangedOverride:
 			if(dg->returnType != ReturnType_Void)
@@ -641,6 +645,7 @@ float Callback_float(DHooksCallback *dg, void **argStack)
 			g_SHPtr->SetRes(MRES_SUPERCEDE);
 			mres = MRES_SUPERCEDE;
 			CallVFunction<float>(dg, paramStruct, g_SHPtr->GetIfacePtr());
+			g_SHPtr->EndContext(NULL);
 			break;
 		case MRES_Override:
 			if(dg->returnType != ReturnType_Void)
@@ -778,6 +783,7 @@ SDKVector *Callback_vector(DHooksCallback *dg, void **argStack)
 			g_SHPtr->SetRes(MRES_SUPERCEDE);
 			mres = MRES_SUPERCEDE;
 			*vec_result = CallVFunction<SDKVector>(dg, paramStruct, g_SHPtr->GetIfacePtr());
+			g_SHPtr->EndContext(NULL);
 			break;
 		case MRES_ChangedOverride:
 			if(dg->returnType != ReturnType_Void)
@@ -798,6 +804,7 @@ SDKVector *Callback_vector(DHooksCallback *dg, void **argStack)
 			g_SHPtr->SetRes(MRES_SUPERCEDE);
 			mres = MRES_SUPERCEDE;
 			CallVFunction<SDKVector>(dg, paramStruct, g_SHPtr->GetIfacePtr());
+			g_SHPtr->EndContext(NULL);
 			break;
 		case MRES_Override:
 			if(dg->returnType != ReturnType_Void)
@@ -926,6 +933,7 @@ string_t *Callback_stringt(DHooksCallback *dg, void **argStack)
 			g_SHPtr->SetRes(MRES_SUPERCEDE);
 			mres = MRES_SUPERCEDE;
 			*string_result = CallVFunction<string_t>(dg, paramStruct, g_SHPtr->GetIfacePtr());
+			g_SHPtr->EndContext(NULL);
 			break;
 		case MRES_ChangedOverride:
 			if(dg->returnType != ReturnType_Void)
@@ -946,6 +954,7 @@ string_t *Callback_stringt(DHooksCallback *dg, void **argStack)
 			g_SHPtr->SetRes(MRES_SUPERCEDE);
 			mres = MRES_SUPERCEDE;
 			CallVFunction<SDKVector>(dg, paramStruct, g_SHPtr->GetIfacePtr());
+			g_SHPtr->EndContext(NULL);
 			break;
 		case MRES_Override:
 			if(dg->returnType != ReturnType_Void)


### PR DESCRIPTION
This reverts commit 67b3b54ae1595db6c8f270dec1c1e6702d3fe9d5

This fixes multiple memory leaks that result in a really long parsing of the linked list, and gives me for example 30 seconds before a round loads after an uptime of 6000 (after a server restart, it usually takes 1 second to load).
Look at MapEntity_ParseAllEntities in the [vprof.txt](https://github.com/peace-maker/DHooks2/files/5597870/vprof.txt) for an example.
