### PR TITLE
#23 `DHookGetParamAddress` + `DHookParam.GetAddress`

### DIFF
--- a/natives.cpp
+++ b/natives.cpp
@@ -1411,6 +1411,33 @@ cell_t Native_IsNullParam(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Param is not a pointer!");
 }
 
+//native Address:DHookGetParamAddress(Handle:hParams, num);
+cell_t Native_GetParamAddress(IPluginContext *pContext, const cell_t *params)
+{
+	HookParamsStruct *paramStruct;
+
+	if(!GetCallbackArgHandleIfValidOrError(g_HookParamsHandle, g_HookReturnHandle, (void **)&paramStruct, pContext, params[1]))
+	{
+		return 0;
+	}
+
+	if(params[2] <= 0 || params[2] > (int)paramStruct->dg->params.size())
+	{
+		return pContext->ThrowNativeError("Invalid param number %i max params is %i", params[2], paramStruct->dg->params.size());
+	}
+
+	int index = params[2] - 1;
+
+	HookParamType type = paramStruct->dg->params.at(index).type;
+	if(type != HookParamType_StringPtr && type != HookParamType_CharPtr && type != HookParamType_VectorPtr && type != HookParamType_CBaseEntity && type != HookParamType_ObjectPtr && type != HookParamType_Edict && type != HookParamType_Unknown)
+	{	
+		return pContext->ThrowNativeError("Param is not a pointer!");
+	}
+
+	size_t offset = GetParamOffset(paramStruct, index);
+	return *(cell_t *)((intptr_t)paramStruct->orgParams + offset);
+}
+
 sp_nativeinfo_t g_Natives[] = 
 {
 	{"DHookCreate",							Native_CreateHook},
@@ -1444,6 +1471,7 @@ sp_nativeinfo_t g_Natives[] =
 	{"DHookSetParamObjectPtrVarVector",		Native_SetParamObjectPtrVarVector},
 	{"DHookGetParamObjectPtrString",		Native_GetParamObjectPtrString},
 	{"DHookIsNullParam",					Native_IsNullParam},
+	{"DHookGetParamAddress",				Native_GetParamAddress},
 
   // Methodmap API
   {"DHookSetup.AddParam",             Native_AddParam},
@@ -1473,6 +1501,7 @@ sp_nativeinfo_t g_Natives[] =
   {"DHookParam.SetObjectVar",         Native_SetParamObjectPtrVar},
   {"DHookParam.SetObjectVarVector",   Native_SetParamObjectPtrVarVector},
   {"DHookParam.IsNull",               Native_IsNullParam},
+  {"DHookParam.GetAddress",           Native_GetParamAddress},
 
   {"DHookReturn.Value.get",           Native_GetReturn},
   {"DHookReturn.Value.set",           Native_SetReturn},

--- a/sourcemod_files/scripting/include/dhooks.inc
+++ b/sourcemod_files/scripting/include/dhooks.inc
@@ -339,6 +339,15 @@ methodmap DHookParam < Handle
 	// @return              True if null, false otherwise.
 	// @error               Non-pointer parameter.
 	public native bool IsNull(int num);
+
+	// Get param address (Use only for ptr param types)
+	// 
+	// @param hParams		Handle to params structure
+	// @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1. 0 Will return the number of params stored)
+	// 
+	// @error Invalid handle. Invalid param number. Invalid param type.
+	// @return address of the parameter.
+	public native Address GetAddress(int num);
 };
 
 
@@ -930,6 +939,16 @@ native void DHookGetParamObjectPtrString(Handle hParams, int num, int offset, Ob
 */
 native bool DHookIsNullParam(Handle hParams, int num);
 
+/* Get param address (Use only for ptr param types)
+ * 
+ * @param hParams		Handle to params structure
+ * @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1. 0 Will return the number of params stored)
+ * 
+ * @error Invalid handle. Invalid param number. Invalid param type.
+ * @return address of the parameter.
+*/
+native Address DHookGetParamAddress(Handle hParams, int num);
+
 public Extension __ext_dhooks =
 {
 	name = "dhooks",
@@ -980,6 +999,7 @@ public __ext_dhooks_SetNTVOptional()
 	MarkNativeAsOptional("DHookSetParamObjectPtrVarVector");
 	MarkNativeAsOptional("DHookIsNullParam");
 	MarkNativeAsOptional("DHookGetParamObjectPtrString");
+	MarkNativeAsOptional("DHookGetParamAddress");
 
 	MarkNativeAsOptional("DHookParam.IsNull");
 	MarkNativeAsOptional("DHookParam.Get");
@@ -993,6 +1013,7 @@ public __ext_dhooks_SetNTVOptional()
 	MarkNativeAsOptional("DHookParam.GetObjectVarString");
 	MarkNativeAsOptional("DHookParam.SetObjectVar");
 	MarkNativeAsOptional("DHookParam.SetObjectVarVector");
+	MarkNativeAsOptional("DHookParam.GetAddress");
 	MarkNativeAsOptional("DHookReturn.Value.get");
 	MarkNativeAsOptional("DHookReturn.Value.set");
 	MarkNativeAsOptional("DHookReturn.GetVector");

--- a/sourcemod_files/scripting/include/dhooks.inc
+++ b/sourcemod_files/scripting/include/dhooks.inc
@@ -342,8 +342,7 @@ methodmap DHookParam < Handle
 
 	// Get param address (Use only for ptr param types)
 	// 
-	// @param hParams		Handle to params structure
-	// @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1. 0 Will return the number of params stored)
+	// @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
 	// 
 	// @error Invalid handle. Invalid param number. Invalid param type.
 	// @return address of the parameter.
@@ -942,7 +941,7 @@ native bool DHookIsNullParam(Handle hParams, int num);
 /* Get param address (Use only for ptr param types)
  * 
  * @param hParams		Handle to params structure
- * @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1. 0 Will return the number of params stored)
+ * @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
  * 
  * @error Invalid handle. Invalid param number. Invalid param type.
  * @return address of the parameter.


### PR DESCRIPTION
Tested:
```cpp
Address param_address = DHookGetParamAddress(hParams, 2);
PrintToChatAll("%d ?= %d", hParams.GetObjectVar(2, 8, ObjectValueType_Int), LoadFromAddress(param_address + view_as<Address>(8), NumberType_Int32));
// 2 ?= 2
```

Closes #23.